### PR TITLE
feat: Update toast list rendering animation

### DIFF
--- a/src/components/toast/ToastContainer.tsx
+++ b/src/components/toast/ToastContainer.tsx
@@ -1,13 +1,13 @@
-import { Itoast } from './useToast';
-import Toast from './Toast';
-import { useEffect, useRef } from 'react';
+import { Itoast } from "./useToast";
+import Toast from "./Toast";
+import { useEffect, useRef } from "react";
 
 type ToastContainerType = {
   toasts: Itoast[];
   removeToast: (id: string) => void;
-}
+};
 
-const ToastContainer = ({toasts, removeToast} : ToastContainerType) => {
+const ToastContainer = ({ toasts, removeToast }: ToastContainerType) => {
   console.log(toasts);
   const toastRefs = useRef<HTMLDivElement[]>([]);
 
@@ -19,19 +19,27 @@ const ToastContainer = ({toasts, removeToast} : ToastContainerType) => {
   return (
     <div className="toast-container">
       {toasts.map((toast, index) => (
-        <Toast
-          // ref={el => {
-          //   if (!toastRefs.current[index]) {
-          //     toastRefs.current[index] = React.createRef();
-          //   }
-          //   if (el) {
-          //     toastRefs.current[index].current = el;
-          //   }
-          // }}
+        <div
+          style={{
+            position: "absolute",
+            top: 55 * index,
+            transition: "top 230ms cubic-bezier(0.21, 1.02, 0.73, 1) 0s",
+          }}
           key={toast.id}
-          toast={toast}
-          removeToast={removeToast}
-        />
+        >
+          <Toast
+            // ref={el => {
+            //   if (!toastRefs.current[index]) {
+            //     toastRefs.current[index] = React.createRef();
+            //   }
+            //   if (el) {
+            //     toastRefs.current[index].current = el;
+            //   }
+            // }}
+            toast={toast}
+            removeToast={removeToast}
+          />
+        </div>
       ))}
     </div>
   );


### PR DESCRIPTION
## Issue
https://github.com/widse/react-toast/issues/1

## Details
새로운 Toast가 추가될 때 나머지 Elements의 위치를 이동시키는 Animation이 필요하므로
Top 값을 Index기준으로 계산하여 처리하는 방법을 제시

(기존)
![before](https://github.com/widse/react-toast/assets/32917014/8209cb6a-dea2-4af7-99b8-8b27728ef5da)

(변경 후)
![after](https://github.com/widse/react-toast/assets/32917014/9272c01d-65e6-46b3-b151-be6ea076e0df)
